### PR TITLE
broadcom-sta-dkms Linux 6.12 support for Jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+broadcom-sta (6.30.223.271-25pop1) noble; urgency=medium
+
+  * Backport to Pop!_OS
+
+ -- Michael Aaron Murphy <michael@mmurphy.dev>  Tue, 18 Feb 2025 10:19:55 +0100
+
 broadcom-sta (6.30.223.271-25) unstable; urgency=low
 
   [ Eduard Bloch ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-broadcom-sta (6.30.223.271-25pop1) noble; urgency=medium
+broadcom-sta (6.30.223.271+bdcom-0ubuntu10pop2) noble; urgency=medium
 
   * Backport to Pop!_OS
 

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,7 @@ Maintainer: Eduard Bloch <blade@debian.org>
 Uploaders: Cyril Lacoux <clacoux@easter-eggs.com>, Roger Shimizu <rosh@debian.org>
 Build-Depends:
  debhelper-compat (= 12),
- dh-sequence-dkms,
- dh-dkms
+ dh-modaliases,
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 XS-Autobuild: yes


### PR DESCRIPTION
Will push to `master_jammy` instead when approved.

Needed by https://github.com/pop-os/linux/pull/347